### PR TITLE
Fix to_excel usage in ventas module

### DIFF
--- a/modules/ventas.py
+++ b/modules/ventas.py
@@ -152,7 +152,7 @@ def ventas_module():
                     st.dataframe(df_procesado)
                     st.download_button(
                         label="Descargar consumo teórico procesado",
-                        data=df_procesado.to_excel(index=False, engine="xlsxwriter"),
+                        data=to_excel_bytes(df_procesado),
                         file_name=output_file,
                         mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
                     )


### PR DESCRIPTION
## Summary
- fix DataFrame.to_excel usage in ventas module when preparing download

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68913d739304832e931185feb2964fd4