### PR TITLE
Centralize path constants and ensure directory creation

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,8 @@
 import streamlit as st
+from utils.paths import ensure_dirs
+
+ensure_dirs()
+
 from modules.catalogo import catalogo_module
 from modules.recetas import recetas_module
 from modules.stock import stock_module

--- a/crear_estructura.py
+++ b/crear_estructura.py
@@ -1,35 +1,24 @@
 import os
 import pandas as pd
+from utils.paths import ensure_dirs, CATALOGO_PATH, RECETAS_PATH, PLANTILLAS_FOLDER
 
-folders = [
-    "catalogo",
-    "recetas",
-    "entradas",
-    "transferencias",
-    "ventas_procesadas",
-    "auditorias/apertura",
-    "auditorias/cierre",
-    "cierres_confirmados",
-    "plantillas"
-]
-
-for folder in folders:
-    os.makedirs(folder, exist_ok=True)
+ensure_dirs()
 print("✅ Carpetas creadas.")
 
 # Crear archivos vacíos de Excel si no existen
-if not os.path.exists("catalogo/catalogo.xlsx"):
-    pd.DataFrame(columns=["Item", "Subcategoría", "Tipo de unidad", "Cantidad por unidad"]).to_excel("catalogo/catalogo.xlsx", index=False)
+if not os.path.exists(CATALOGO_PATH):
+    pd.DataFrame(columns=["Item", "Subcategoría", "Tipo de unidad", "Cantidad por unidad"]).to_excel(CATALOGO_PATH, index=False)
     print("✅ catalogo/catalogo.xlsx generado.")
 
-if not os.path.exists("recetas/recetas.xlsx"):
-    with pd.ExcelWriter("recetas/recetas.xlsx") as writer:
+if not os.path.exists(RECETAS_PATH):
+    with pd.ExcelWriter(RECETAS_PATH) as writer:
         pd.DataFrame(columns=["Producto vendido", "Item usado", "Subcategoría", "Cantidad usada"]).to_excel(writer, sheet_name="Recetas", index=False)
         pd.DataFrame(columns=["Categoría","Subcategoría","Tipo de unidad","Cantidad estándar usada"]).to_excel(writer, sheet_name="ReglasEst", index=False)
     print("✅ recetas/recetas.xlsx generado.")
 
-if not os.path.exists("plantillas/formato_conteo.xlsx"):
-    pd.DataFrame(columns=["Fecha","Item","Subcategoría","Ubicación","Conteo Apertura","Requisicion","Conteo Cierre","Observaciones"]).to_excel("plantillas/formato_conteo.xlsx", index=False)
+formato_path = os.path.join(PLANTILLAS_FOLDER, "formato_conteo.xlsx")
+if not os.path.exists(formato_path):
+    pd.DataFrame(columns=["Fecha","Item","Subcategoría","Ubicación","Conteo Apertura","Requisicion","Conteo Cierre","Observaciones"]).to_excel(formato_path, index=False)
     print("✅ plantillas/formato_conteo.xlsx generado.")
 
 print("🚀 Estructura terminada, ¡puedes empezar a usar la app!")

--- a/modules/auditorias.py
+++ b/modules/auditorias.py
@@ -4,15 +4,16 @@ import os
 from datetime import datetime
 from utils.pdf_report import generar_pdf_cierre, generar_pdf_apertura  # deja tu stub
 from utils.excel_tools import to_excel_bytes  # <<< AGREGA ESTA LINEA
-
-CATALOGO_PATH = "catalogo/catalogo.xlsx"
-ENTRADAS_FOLDER = "entradas/"
-TRANSFERENCIAS_FOLDER = "transferencias/"
-VENTAS_PROCESADAS_FOLDER = "ventas_procesadas/"
-CIERRES_CONFIRMADOS_FOLDER = "cierres_confirmados/"
-AUDITORIA_AP_FOLDER = "auditorias/apertura/"
-AUDITORIA_CI_FOLDER = "auditorias/cierre/"
-REPORTES_PDF_FOLDER = "reportes_pdf/"
+from utils.paths import (
+    CATALOGO_PATH,
+    ENTRADAS_FOLDER,
+    TRANSFERENCIAS_FOLDER,
+    VENTAS_PROCESADAS_FOLDER,
+    CIERRES_CONFIRMADOS_FOLDER,
+    AUDITORIA_AP_FOLDER,
+    AUDITORIA_CI_FOLDER,
+    REPORTES_PDF_FOLDER,
+)
 
 def registrar_requisiciones(df_audit, fecha):
     df_requis = df_audit[(df_audit["Requisicion"] > 0)]

--- a/modules/catalogo.py
+++ b/modules/catalogo.py
@@ -2,9 +2,7 @@ import streamlit as st
 import pandas as pd
 import os
 from utils.excel_tools import to_excel_bytes
-
-
-CATALOGO_PATH = "catalogo/catalogo.xlsx"
+from utils.paths import CATALOGO_PATH
 
 def load_catalog():
     """Carga el catálogo de productos desde Excel."""

--- a/modules/entradas.py
+++ b/modules/entradas.py
@@ -3,9 +3,7 @@ import pandas as pd
 import os
 from datetime import datetime
 from utils.excel_tools import to_excel_bytes
-
-CATALOGO_PATH = "catalogo/catalogo.xlsx"
-ENTRADAS_FOLDER = "entradas/"
+from utils.paths import CATALOGO_PATH, ENTRADAS_FOLDER
 
 def save_entrada(df, fecha):
     """

--- a/modules/historial.py
+++ b/modules/historial.py
@@ -3,14 +3,22 @@ import pandas as pd
 import os
 from glob import glob
 from utils.excel_tools import to_excel_bytes  # <-- AGREGA ESTA LÍNEA
+from utils.paths import (
+    ENTRADAS_FOLDER,
+    TRANSFERENCIAS_FOLDER,
+    VENTAS_PROCESADAS_FOLDER,
+    AUDITORIA_AP_FOLDER,
+    AUDITORIA_CI_FOLDER,
+    CIERRES_CONFIRMADOS_FOLDER,
+)
 
 CARPETAS = {
-    "Entradas": "entradas/",
-    "Transferencias": "transferencias/",
-    "Ventas procesadas": "ventas_procesadas/",
-    "Auditoría apertura": "auditorias/apertura/",
-    "Auditoría cierre": "auditorias/cierre/",
-    "Cierres confirmados": "cierres_confirmados/"
+    "Entradas": ENTRADAS_FOLDER,
+    "Transferencias": TRANSFERENCIAS_FOLDER,
+    "Ventas procesadas": VENTAS_PROCESADAS_FOLDER,
+    "Auditoría apertura": AUDITORIA_AP_FOLDER,
+    "Auditoría cierre": AUDITORIA_CI_FOLDER,
+    "Cierres confirmados": CIERRES_CONFIRMADOS_FOLDER,
 }
 
 def cargar_historial(tipo, path):

--- a/modules/plantillas.py
+++ b/modules/plantillas.py
@@ -3,9 +3,7 @@ import pandas as pd
 import os
 from datetime import datetime
 from utils.excel_tools import to_excel_bytes  # <-- AGREGA ESTA LÍNEA
-
-CATALOGO_PATH = "catalogo/catalogo.xlsx"
-PLANTILLAS_FOLDER = "plantillas/"
+from utils.paths import CATALOGO_PATH, PLANTILLAS_FOLDER
 
 def generar_plantilla_catalogo():
     """

--- a/modules/recetas.py
+++ b/modules/recetas.py
@@ -2,8 +2,7 @@ import streamlit as st
 import pandas as pd
 import os
 from utils.excel_tools import to_excel_bytes_multiple_sheets
-
-RECETAS_PATH = "recetas/recetas.xlsx"
+from utils.paths import RECETAS_PATH
 
 def load_recetas():
     """

--- a/modules/stock.py
+++ b/modules/stock.py
@@ -2,12 +2,13 @@ import streamlit as st
 import pandas as pd
 import os
 from utils.excel_tools import to_excel_bytes
-
-CATALOGO_PATH = "catalogo/catalogo.xlsx"
-ENTRADAS_FOLDER = "entradas/"
-TRANSFERENCIAS_FOLDER = "transferencias/"
-VENTAS_PROCESADAS_FOLDER = "ventas_procesadas/"
-CIERRES_CONFIRMADOS_FOLDER = "cierres_confirmados/"
+from utils.paths import (
+    CATALOGO_PATH,
+    ENTRADAS_FOLDER,
+    TRANSFERENCIAS_FOLDER,
+    VENTAS_PROCESADAS_FOLDER,
+    CIERRES_CONFIRMADOS_FOLDER,
+)
 
 def load_all_entradas():
     archivos = [f for f in os.listdir(ENTRADAS_FOLDER) if f.endswith('.xlsx')]

--- a/modules/transferencias.py
+++ b/modules/transferencias.py
@@ -2,8 +2,7 @@ import streamlit as st
 import pandas as pd
 import os
 from utils.excel_tools import to_excel_bytes  # <-- AGREGA ESTA LÍNEA
-
-TRANSFERENCIAS_FOLDER = "transferencias/"
+from utils.paths import TRANSFERENCIAS_FOLDER
 
 def load_all_transferencias():
     """Carga y concatena todas las transferencias registradas (manuales y automáticas)."""

--- a/modules/ventas.py
+++ b/modules/ventas.py
@@ -3,10 +3,7 @@ import pandas as pd
 import os
 from datetime import datetime
 from utils.excel_tools import to_excel_bytes  # Agrega esta línea
-
-CATALOGO_PATH = "catalogo/catalogo.xlsx"
-RECETAS_PATH = "recetas/recetas.xlsx"
-VENTAS_PROCESADAS_FOLDER = "ventas_procesadas/"
+from utils.paths import CATALOGO_PATH, RECETAS_PATH, VENTAS_PROCESADAS_FOLDER
 
 VINERA_SUBCATEGORIAS = set([
     "Blancos", "Tintos", "Espumantes", "Rosados", "Spirits & Wine"

--- a/utils/paths.py
+++ b/utils/paths.py
@@ -1,0 +1,34 @@
+import os
+
+# File paths
+CATALOGO_PATH = "catalogo/catalogo.xlsx"
+RECETAS_PATH = "recetas/recetas.xlsx"
+
+# Folder paths
+ENTRADAS_FOLDER = "entradas/"
+TRANSFERENCIAS_FOLDER = "transferencias/"
+VENTAS_PROCESADAS_FOLDER = "ventas_procesadas/"
+AUDITORIA_AP_FOLDER = "auditorias/apertura/"
+AUDITORIA_CI_FOLDER = "auditorias/cierre/"
+CIERRES_CONFIRMADOS_FOLDER = "cierres_confirmados/"
+PLANTILLAS_FOLDER = "plantillas/"
+REPORTES_PDF_FOLDER = "reportes_pdf/"
+
+
+def ensure_dirs() -> None:
+    """Create required directories if they do not exist."""
+    dirs = [
+        os.path.dirname(CATALOGO_PATH),
+        os.path.dirname(RECETAS_PATH),
+        ENTRADAS_FOLDER,
+        TRANSFERENCIAS_FOLDER,
+        VENTAS_PROCESADAS_FOLDER,
+        AUDITORIA_AP_FOLDER,
+        AUDITORIA_CI_FOLDER,
+        CIERRES_CONFIRMADOS_FOLDER,
+        PLANTILLAS_FOLDER,
+        REPORTES_PDF_FOLDER,
+    ]
+    for folder in dirs:
+        if folder:
+            os.makedirs(folder, exist_ok=True)


### PR DESCRIPTION
## Summary
- add `utils/paths.py` with shared file and folder constants
- implement `ensure_dirs()` to create required directories
- update modules to import path constants and call `ensure_dirs` at startup

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68915996aed0832eb8c0ed6968f2802f