### PR TITLE
Add unit conversion utilities and display stock in bottles

### DIFF
--- a/modules/stock.py
+++ b/modules/stock.py
@@ -2,6 +2,7 @@ import streamlit as st
 import pandas as pd
 import os
 from utils.excel_tools import to_excel_bytes
+from utils.unit_conversion import to_bottles
 from utils.path_utils import (
     CATALOGO_DIR,
     ENTRADAS_DIR,
@@ -94,7 +95,7 @@ def stock_module():
             if not stock_inicial.empty:
                 match = stock_inicial[(stock_inicial["Item"] == item) & (stock_inicial["Ubicación"] == ubic)]
                 if not match.empty:
-                    cantidad = match.iloc[0]["Cantidad"] if "Cantidad" in match.columns else match.iloc[0].get("Físico Cierre",0)
+                    cantidad = match.iloc[0]["Cantidad"] if "Cantidad" in match.columns else match.iloc[0].get("Físico Cierre", 0)
             # Sumar entradas a esa ubicación
             if not entradas.empty:
                 entradas_sum = entradas[(entradas["Item"] == item) & (entradas["Ubicación destino"] == ubic)]["Cantidad"].sum()
@@ -108,7 +109,14 @@ def stock_module():
             if ubic in ["Barra", "Vinera"] and not ventas.empty:
                 consumo = ventas[(ventas["Item usado"] == item) & (ventas["Ubicación de salida"] == ubic)]["Cantidad teórica consumida"].sum()
                 cantidad -= consumo
-            stock.append({"Item": item, "Ubicación": ubic, "Stock Actual": cantidad})
+
+            stock_botellas = to_bottles(item, cantidad, cat)
+            stock.append({
+                "Item": item,
+                "Ubicación": ubic,
+                "Stock Actual": cantidad,
+                "Stock Botellas": round(stock_botellas, 2) if stock_botellas is not None else None,
+            })
 
     df_stock = pd.DataFrame(stock)
 

--- a/utils/unit_conversion.py
+++ b/utils/unit_conversion.py
@@ -1,0 +1,45 @@
+import pandas as pd
+
+
+def to_ml(item: str, cantidad: float, catalogo: pd.DataFrame) -> float:
+    """Convert `cantidad` to milliliters based on catalog info.
+
+    If the item has "Tipo de unidad" == "ml" and "Cantidad por unidad" > 0,
+    the input is assumed to be expressed in whole bottles and is converted to ml.
+    Otherwise the quantity is returned unchanged.
+    """
+    if catalogo is None or catalogo.empty:
+        return cantidad
+    row = catalogo[catalogo["Item"] == item]
+    if row.empty:
+        return cantidad
+    tipo = row.iloc[0].get("Tipo de unidad")
+    capacidad = row.iloc[0].get("Cantidad por unidad")
+    try:
+        if tipo == "ml" and pd.notnull(capacidad) and float(capacidad) > 0:
+            return float(cantidad) * float(capacidad)
+    except Exception:
+        pass
+    return cantidad
+
+
+def to_bottles(item: str, cantidad_ml: float, catalogo: pd.DataFrame):
+    """Return the number of bottles represented by `cantidad_ml`.
+
+    If the catalog registers the item in milliliters and has a valid
+    "Cantidad por unidad", the value is converted and returned. In case the
+    conversion cannot be performed, ``None`` is returned.
+    """
+    if catalogo is None or catalogo.empty:
+        return None
+    row = catalogo[catalogo["Item"] == item]
+    if row.empty:
+        return None
+    tipo = row.iloc[0].get("Tipo de unidad")
+    capacidad = row.iloc[0].get("Cantidad por unidad")
+    try:
+        if tipo == "ml" and pd.notnull(capacidad) and float(capacidad) > 0:
+            return float(cantidad_ml) / float(capacidad)
+    except Exception:
+        pass
+    return None


### PR DESCRIPTION
## Summary
- add shared unit conversion helpers to go between bottles and milliliters
- show bottle counts in stock view
- convert audit counts to milliliters before processing

## Testing
- `python -m py_compile modules/auditorias.py modules/stock.py utils/unit_conversion.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68914631aca0832eb280dd6aad2d07ed