### PR TITLE
Create missing data directories at startup

### DIFF
--- a/utils/path_utils.py
+++ b/utils/path_utils.py
@@ -13,6 +13,23 @@ AUDITORIA_CI_DIR = os.path.join(DATA_DIR, "auditorias", "cierre")
 CIERRES_CONFIRMADOS_DIR = os.path.join(DATA_DIR, "cierres_confirmados")
 REPORTES_PDF_DIR = os.path.join(DATA_DIR, "reportes_pdf")
 
+# Ensure expected directory structure exists so other modules can safely
+# list or write files without triggering FileNotFoundError when the app
+# runs for the first time.
+for _dir in [
+    CATALOGO_DIR,
+    RECETAS_DIR,
+    PLANTILLAS_DIR,
+    ENTRADAS_DIR,
+    TRANSFERENCIAS_DIR,
+    VENTAS_PROCESADAS_DIR,
+    AUDITORIA_AP_DIR,
+    AUDITORIA_CI_DIR,
+    CIERRES_CONFIRMADOS_DIR,
+    REPORTES_PDF_DIR,
+]:
+    os.makedirs(_dir, exist_ok=True)
+
 def latest_file(folder, prefix):
     """Return the newest Excel file matching prefix_YYYY-MM-DD.xlsx in folder."""
     files = sorted(glob(os.path.join(folder, f"{prefix}_*.xlsx")))


### PR DESCRIPTION
## Summary
- ensure required data directories are created automatically so modules can list files without crashing

## Testing
- `python - <<'PY'
from utils.path_utils import ENTRADAS_DIR, TRANSFERENCIAS_DIR, CIERRES_CONFIRMADOS_DIR
import os
print('ENTRADAS:', os.path.isdir(ENTRADAS_DIR), ENTRADAS_DIR)
print('TRANSFERENCIAS:', os.path.isdir(TRANSFERENCIAS_DIR), TRANSFERENCIAS_DIR)
print('CIERRES_CONFIRMADOS:', os.path.isdir(CIERRES_CONFIRMADOS_DIR), CIERRES_CONFIRMADOS_DIR)
PY`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689160ff26a8832e89840a167cd6268e