### PR TITLE
Refine stock view and enable in-memory PDF exports

### DIFF
--- a/modules/auditorias.py
+++ b/modules/auditorias.py
@@ -99,14 +99,12 @@ def auditoria_apertura():
         outfile = f"auditoria_apertura_{fecha.strftime('%Y-%m-%d')}.xlsx"
         pdfout = outfile.replace('.xlsx', '.pdf')
         df_res.to_excel(os.path.join(AUDITORIA_AP_FOLDER, outfile), index=False)
-        generar_pdf_apertura(df_res, os.path.join(REPORTES_PDF_FOLDER, pdfout))
+        pdf_bytes = generar_pdf_apertura(df_res, os.path.join(REPORTES_PDF_FOLDER, pdfout))
         st.success("Auditoría procesada y registrada.")
         st.dataframe(df_res)
         # USAR EL NUEVO PATRÓN PARA DESCARGA
-        st.download_button("Descargar auditoría (Excel)", data=to_excel_bytes(df_res),
-            file_name=outfile)
-        with open(os.path.join(REPORTES_PDF_FOLDER, pdfout), "rb") as f:
-            st.download_button("Descargar auditoría (PDF)", data=f, file_name=pdfout, mime="application/pdf")
+        st.download_button("Descargar auditoría (Excel)", data=to_excel_bytes(df_res), file_name=outfile)
+        st.download_button("Descargar auditoría (PDF)", data=pdf_bytes, file_name=pdfout, mime="application/pdf")
 
 def auditoria_cierre():
     st.title("Auditoría de Cierre")
@@ -192,9 +190,8 @@ def auditoria_cierre():
         outfile = f"auditoria_cierre_{fecha.strftime('%Y-%m-%d')}.xlsx"
         pdfout = outfile.replace('.xlsx', '.pdf')
         df_res.to_excel(os.path.join(AUDITORIA_CI_FOLDER, outfile), index=False)
-        generar_pdf_cierre(df_res, os.path.join(REPORTES_PDF_FOLDER, pdfout))
+        pdf_bytes = generar_pdf_cierre(df_res, os.path.join(REPORTES_PDF_FOLDER, pdfout))
         st.success("Auditoría de cierre procesada y registrada.")
         st.dataframe(df_res)
         st.download_button("Descargar auditoría (Excel)", data=to_excel_bytes(df_res), file_name=outfile)
-        with open(os.path.join(REPORTES_PDF_FOLDER, pdfout), "rb") as f:
-            st.download_button("Descargar auditoría (PDF)", data=f, file_name=pdfout, mime="application/pdf")
+        st.download_button("Descargar auditoría (PDF)", data=pdf_bytes, file_name=pdfout, mime="application/pdf")

--- a/utils/pdf_report.py
+++ b/utils/pdf_report.py
@@ -38,7 +38,7 @@ class PDF(FPDF):
                 self.cell(col_widths[i], 8, val[:25], 1, 0, "C")
             self.ln()
 
-def generar_pdf_apertura(df, ruta_pdf):
+def generar_pdf_apertura(df, ruta_pdf=None):
     pdf = PDF()
     pdf.title = "Auditoría de Apertura de Inventario"
     pdf.add_page()
@@ -50,9 +50,13 @@ def generar_pdf_apertura(df, ruta_pdf):
     pdf.ln(6)
     pdf.set_font("Arial", "I", 10)
     pdf.cell(0, 10, "Auditoría generada automáticamente por el sistema de inventario.", ln=1)
-    pdf.output(ruta_pdf)
+    pdf_bytes = pdf.output(dest="S").encode("latin-1")
+    if ruta_pdf:
+        with open(ruta_pdf, "wb") as f:
+            f.write(pdf_bytes)
+    return pdf_bytes
 
-def generar_pdf_cierre(df, ruta_pdf):
+def generar_pdf_cierre(df, ruta_pdf=None):
     pdf = PDF()
     pdf.title = "Auditoría de Cierre de Inventario"
     pdf.add_page()
@@ -68,4 +72,8 @@ def generar_pdf_cierre(df, ruta_pdf):
     pdf.ln(6)
     pdf.set_font("Arial", "I", 10)
     pdf.cell(0, 10, "Auditoría generada automáticamente por el sistema de inventario.", ln=1)
-    pdf.output(ruta_pdf)
+    pdf_bytes = pdf.output(dest="S").encode("latin-1")
+    if ruta_pdf:
+        with open(ruta_pdf, "wb") as f:
+            f.write(pdf_bytes)
+    return pdf_bytes


### PR DESCRIPTION
## Summary
- filter cocktail items out of stock listings and hide zero-stock locations
- generate PDF reports in memory for opening/closing audits
- update audit modules to serve PDF bytes directly

## Testing
- `python -m py_compile modules/stock.py modules/auditorias.py utils/pdf_report.py`


------
https://chatgpt.com/codex/tasks/task_e_689169137820832e948a7ae3125e1ddf