### PR TITLE
Refactor inventory structures for Excel-based catalog and recipes

### DIFF
--- a/modules/recetas.py
+++ b/modules/recetas.py
@@ -1,53 +1,83 @@
-import streamlit as st
-import pandas as pd
 import os
-from utils.excel_tools import to_excel_bytes_multiple_sheets
-from utils.path_utils import RECETAS_DIR, latest_file
+import pandas as pd
+import streamlit as st
 
-def load_recetas():
-    """
-    Carga las hojas de Recetas y Reglas Estándar desde el archivo más reciente
-    ubicado en `data/recetas/`. Si no existen, devuelve DataFrames vacíos con
-    las columnas correctas.
-    """
+from utils.excel_tools import to_excel_bytes
+from utils.path_utils import RECETAS_DIR, latest_file
+from modules.catalogo import load_catalog
+
+
+EXPECTED_COLUMNS = [
+    "Producto_vendido",
+    "Ingrediente",
+    "Cantidad_usada",
+    "Unidad",
+]
+
+
+def load_recetas(catalogo: pd.DataFrame | None = None) -> pd.DataFrame:
+    """Carga y valida la hoja de recetas."""
     path = latest_file(RECETAS_DIR, "recetas")
     if path and os.path.exists(path):
         try:
-            xls = pd.ExcelFile(path)
-            # Espera dos hojas exactas: 'Recetas' y 'ReglasEst'
-            df_recetas = pd.read_excel(xls, "Recetas")
-            df_reglas = pd.read_excel(xls, "ReglasEst")
+            df = pd.read_excel(path)
         except Exception as e:
-            st.error(f"Error cargando recetas.xlsx: {str(e)}")
-            df_recetas = pd.DataFrame(columns=["Producto vendido", "Item usado", "Subcategoría", "Cantidad usada"])
-            df_reglas = pd.DataFrame(columns=["Categoría", "Subcategoría", "Tipo de unidad", "Cantidad estándar usada"])
+            st.error(f"Error cargando recetas.xlsx: {e}")
+            df = pd.DataFrame(columns=EXPECTED_COLUMNS)
     else:
-        df_recetas = pd.DataFrame(columns=["Producto vendido", "Item usado", "Subcategoría", "Cantidad usada"])
-        df_reglas = pd.DataFrame(columns=["Categoría", "Subcategoría", "Tipo de unidad", "Cantidad estándar usada"])
-    return df_recetas, df_reglas
+        df = pd.DataFrame(columns=EXPECTED_COLUMNS)
+
+    missing = [c for c in EXPECTED_COLUMNS if c not in df.columns]
+    if missing:
+        st.error(f"Recetas incompletas. Faltan columnas: {', '.join(missing)}")
+        df = df.reindex(columns=EXPECTED_COLUMNS)
+
+    if catalogo is not None and not df.empty:
+        ctl_products = set(
+            catalogo[catalogo["Tipo_venta"] == "CTL"]["Nombre"].dropna()
+        )
+        for prod in df["Producto_vendido"].dropna().unique():
+            if prod not in ctl_products:
+                st.warning(
+                    f"'{prod}' en recetas no está definido como CTL en el catálogo."
+                )
+
+        catalog_items = set(catalogo["Nombre"].dropna())
+        for ing in df["Ingrediente"].dropna().unique():
+            if ing not in catalog_items:
+                st.warning(
+                    f"Ingrediente '{ing}' no existe en el catálogo."
+                )
+    return df
+
 
 def recetas_module():
-    st.title("Recetas (Consumo Teórico)")
+    st.title("Recetas de Productos Compuestos")
+    st.info(
+        """Las recetas sólo aplican a productos del catálogo con Tipo_venta = CTL.
+        Cada fila representa un ingrediente necesario para preparar una unidad del
+        producto compuesto.
+        ✏️ La edición se realiza directamente en el archivo más reciente dentro de
+        `data/recetas/`.
+        """
+    )
 
-    st.info("""
-    Este módulo muestra las recetas de productos y las reglas estándar de consumo.
-    - La edición/mantenimiento SOLO se realiza en el archivo más reciente dentro de `data/recetas/` (dos hojas: Recetas y ReglasEst).
-    - Las recetas determinan el consumo teórico de inventario a partir de las ventas.
-    """)
-
-    df_recetas, df_reglas = load_recetas()
-
-    st.subheader("Recetas de Productos (por venta)")
+    catalogo = load_catalog()
+    df_recetas = load_recetas(catalogo)
     st.dataframe(df_recetas)
 
-    st.markdown("---")
-    st.subheader("Reglas Estándar (consumo genérico por subcategoría)")
-    st.dataframe(df_reglas)
-
-    # Exportar ambas hojas unificadas, SOLO EN MEMORIA
     st.download_button(
-        label="Descargar archivo de recetas (Excel)",
-        data=to_excel_bytes_multiple_sheets({"Recetas": df_recetas, "ReglasEst": df_reglas}),
+        label="Descargar archivo de recetas", 
+        data=to_excel_bytes(df_recetas),
         file_name="recetas.xlsx",
-        mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     )
+
+    st.info(
+        "**Formato requerido:**\n"
+        "- Producto_vendido\n"
+        "- Ingrediente\n"
+        "- Cantidad_usada\n"
+        "- Unidad"
+    )
+


### PR DESCRIPTION
## Summary
- validate catalog using explicit `Nombre` + `Subcategoría` identifiers with per-type requirements
- introduce recipe loader for CTL products and ingredient validation against catalog
- revamp sales processor to map columns manually and compute consumption without TRG/BOT pairing

## Testing
- `python -m py_compile modules/catalogo.py modules/recetas.py modules/ventas.py`


------
https://chatgpt.com/codex/tasks/task_e_68917633a9ec832e8e3706de9c254393