### PR TITLE
Fix catalog loading and handle missing Item in entradas

### DIFF
--- a/modules/catalogo.py
+++ b/modules/catalogo.py
@@ -1,6 +1,7 @@
 import streamlit as st
 import pandas as pd
 import os
+from glob import glob
 from utils.excel_tools import to_excel_bytes
 from utils.path_utils import CATALOGO_DIR, latest_file
 
@@ -18,6 +19,10 @@ EXPECTED_COLUMNS = [
 def load_catalog():
     """Carga y valida el catálogo de productos desde Excel."""
     path = latest_file(CATALOGO_DIR, "catalogo")
+    if not path:
+        # Fallback to any Excel file in the catalog directory
+        candidates = glob(os.path.join(CATALOGO_DIR, "*.xlsx"))
+        path = candidates[0] if candidates else None
     if path and os.path.exists(path):
         df = pd.read_excel(path)
         if "Item" not in df.columns and "Nombre" in df.columns:

--- a/modules/entradas.py
+++ b/modules/entradas.py
@@ -3,7 +3,8 @@ import pandas as pd
 import os
 from datetime import datetime
 from utils.excel_tools import to_excel_bytes
-from utils.path_utils import CATALOGO_DIR, ENTRADAS_DIR, latest_file
+from utils.path_utils import ENTRADAS_DIR
+from modules.catalogo import load_catalog
 
 ENTRADAS_FOLDER = ENTRADAS_DIR
 
@@ -46,10 +47,9 @@ def entradas_module():
     Todos los registros quedan almacenados en la carpeta `data/entradas/` para respaldo y auditoría.
     """)
 
-    cat_path = latest_file(CATALOGO_DIR, "catalogo")
-    cat = pd.read_excel(cat_path) if cat_path and os.path.exists(cat_path) else pd.DataFrame()
-    if cat.empty:
-        st.warning("El catálogo está vacío. Debes cargar productos primero en el catálogo.")
+    cat = load_catalog()
+    if cat.empty or "Item" not in cat.columns:
+        st.warning("El catálogo está vacío o falta la columna 'Item'.")
         return
         
     fecha = st.date_input("Fecha de entrada", value=datetime.today())


### PR DESCRIPTION
## Summary
- Allow catalog loader to fall back to any Excel file when dated catalog file is missing
- Use `load_catalog` in entradas module and validate presence of `Item`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689189c25b48832e8f75bb9c82ce8825