### PR TITLE
Sanitize PDF generation for latin-1

### DIFF
--- a/utils/pdf_report.py
+++ b/utils/pdf_report.py
@@ -6,19 +6,31 @@ from utils.path_utils import REPORTES_PDF_DIR
 
 LOGO_PATH = os.path.join(REPORTES_PDF_DIR, "logo.png")  # Cambia esto si tu logo está en otra ubicación
 
+
+def _safe_text(text) -> str:
+    """Devuelve *text* convertido a latin-1, reemplazando caracteres no soportados.
+
+    FPDF solo admite el conjunto de caracteres latin-1 para las fuentes básicas.
+    Este helper evita errores de codificación reemplazando cualquier caracter que
+    no pueda representarse.
+    """
+
+    return str(text).encode("latin-1", "replace").decode("latin-1")
+
 class PDF(FPDF):
     def header(self):
         # Logo (opcional)
         if os.path.exists(LOGO_PATH):
             self.image(LOGO_PATH, 10, 8, 20)
         self.set_font('Arial', 'B', 14)
-        self.cell(0, 10, self.title, ln=1, align='C')
+        self.cell(0, 10, _safe_text(self.title), ln=1, align='C')
         self.ln(5)
 
     def footer(self):
         self.set_y(-15)
         self.set_font('Arial', 'I', 8)
-        self.cell(0, 10, f'Página {self.page_no()} - {datetime.today().strftime("%Y-%m-%d %H:%M")}', 0, 0, 'C')
+        footer_text = f'Página {self.page_no()} - {datetime.today().strftime("%Y-%m-%d %H:%M")}'
+        self.cell(0, 10, _safe_text(footer_text), 0, 0, 'C')
 
     def tabla(self, dataframe: pd.DataFrame):
         self.set_font("Arial", size=9)
@@ -29,12 +41,12 @@ class PDF(FPDF):
             col_widths.append(max(18, min(40, max_content*4.2)))
         # Encabezado
         for i, col in enumerate(dataframe.columns):
-            self.cell(col_widths[i], 8, str(col), 1, 0, "C", fill=True)
+            self.cell(col_widths[i], 8, _safe_text(col), 1, 0, "C", fill=True)
         self.ln()
         # Filas
         for idx, row in dataframe.iterrows():
             for i, col in enumerate(dataframe.columns):
-                val = str(row[col])
+                val = _safe_text(row[col])
                 self.cell(col_widths[i], 8, val[:25], 1, 0, "C")
             self.ln()
 
@@ -44,12 +56,12 @@ def generar_pdf_apertura(df, ruta_pdf=None):
     pdf.add_page()
     pdf.set_fill_color(220, 220, 220)
     pdf.set_font("Arial", "B", 11)
-    pdf.cell(0, 10, f"Fecha: {datetime.today().strftime('%Y-%m-%d')}", ln=1)
+    pdf.cell(0, 10, _safe_text(f"Fecha: {datetime.today().strftime('%Y-%m-%d')}"), ln=1)
     pdf.ln(2)
     pdf.tabla(df)
     pdf.ln(6)
     pdf.set_font("Arial", "I", 10)
-    pdf.cell(0, 10, "Auditoría generada automáticamente por el sistema de inventario.", ln=1)
+    pdf.cell(0, 10, _safe_text("Auditoría generada automáticamente por el sistema de inventario."), ln=1)
     pdf_bytes = pdf.output(dest="S").encode("latin-1", "replace")
     if ruta_pdf:
         with open(ruta_pdf, "wb") as f:
@@ -62,16 +74,16 @@ def generar_pdf_cierre(df, ruta_pdf=None):
     pdf.add_page()
     pdf.set_fill_color(220, 220, 220)
     pdf.set_font("Arial", "B", 11)
-    pdf.cell(0, 10, f"Fecha: {datetime.today().strftime('%Y-%m-%d')}", ln=1)
+    pdf.cell(0, 10, _safe_text(f"Fecha: {datetime.today().strftime('%Y-%m-%d')}"), ln=1)
     # Resumen de diferencias
     pdf.set_font("Arial", "", 10)
     dif_total = round(df["Diferencia"].sum(), 2) if "Diferencia" in df else 0
-    pdf.cell(0, 8, f"Total diferencia de stock (todas ubicaciones): {dif_total}", ln=1)
+    pdf.cell(0, 8, _safe_text(f"Total diferencia de stock (todas ubicaciones): {dif_total}"), ln=1)
     pdf.ln(2)
     pdf.tabla(df)
     pdf.ln(6)
     pdf.set_font("Arial", "I", 10)
-    pdf.cell(0, 10, "Auditoría generada automáticamente por el sistema de inventario.", ln=1)
+    pdf.cell(0, 10, _safe_text("Auditoría generada automáticamente por el sistema de inventario."), ln=1)
     pdf_bytes = pdf.output(dest="S").encode("latin-1", "replace")
     if ruta_pdf:
         with open(ruta_pdf, "wb") as f:
@@ -86,12 +98,12 @@ def generar_pdf_stock(df, ruta_pdf=None):
     pdf.add_page()
     pdf.set_fill_color(220, 220, 220)
     pdf.set_font("Arial", "B", 11)
-    pdf.cell(0, 10, f"Fecha: {datetime.today().strftime('%Y-%m-%d')}", ln=1)
+    pdf.cell(0, 10, _safe_text(f"Fecha: {datetime.today().strftime('%Y-%m-%d')}"), ln=1)
     pdf.ln(2)
     pdf.tabla(df.round(2))
     pdf.ln(6)
     pdf.set_font("Arial", "I", 10)
-    pdf.cell(0, 10, "Reporte generado automáticamente por el sistema de inventario.", ln=1)
+    pdf.cell(0, 10, _safe_text("Reporte generado automáticamente por el sistema de inventario."), ln=1)
     pdf_bytes = pdf.output(dest="S").encode("latin-1", "replace")
     if ruta_pdf:
         with open(ruta_pdf, "wb") as f:


### PR DESCRIPTION
## Summary
- sanitize all PDF text using latin-1 replacement to prevent FPDF Unicode errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68919b11ef34832e81cc9482c8704e1d