### PR TITLE
feat: remove template tab and add audit location

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,7 +7,6 @@ from modules.transferencias import transferencias_module
 from modules.ventas import ventas_module
 from modules.auditorias import auditoria_apertura, auditoria_cierre
 from modules.historial import historial_module
-from modules.plantillas import plantilla_module
 from modules.reportes import reportes_module
 
 st.set_page_config(page_title="Gestión Inventario Licores", layout="wide")
@@ -24,8 +23,7 @@ opciones = [
     "Auditoría de Apertura",
     "Auditoría de Cierre",
     "Historial",
-    "Reportes",
-    "Descargar Plantilla de Conteo"
+    "Reportes"
 ]
 eleccion = st.sidebar.radio("Seleccione módulo:", opciones)
 
@@ -50,5 +48,3 @@ elif eleccion == "Historial":
     historial_module()
 elif eleccion == "Reportes":
     reportes_module()
-elif eleccion == "Descargar Plantilla de Conteo":
-    plantilla_module()

--- a/modules/auditorias.py
+++ b/modules/auditorias.py
@@ -25,6 +25,9 @@ AUDITORIA_AP_FOLDER = AUDITORIA_AP_DIR
 AUDITORIA_CI_FOLDER = AUDITORIA_CI_DIR
 REPORTES_PDF_FOLDER = REPORTES_PDF_DIR
 
+# Ubicaciones disponibles para las auditorías
+UBICACIONES = ["Almacén", "Barra", "Vinera"]
+
 def registrar_requisiciones(df_audit, fecha):
     df_requis = df_audit[(df_audit["Requisicion"] > 0)]
     if df_requis.empty:
@@ -54,14 +57,25 @@ def auditoria_apertura():
     Si el archivo tiene columna 'Requisicion', las transferencias declaradas se registrarán automáticamente.
     """)
     fecha = st.date_input("Fecha de auditoría de apertura", value=datetime.today())
-    archivo = st.file_uploader("Selecciona el archivo de conteo de apertura (Excel plantilla oficial)", type=["xlsx"])
+    ubic_sel = st.selectbox(
+        "Ubicación de la auditoría",
+        ["General"] + UBICACIONES,
+    )
+    archivo = st.file_uploader(
+        "Selecciona el archivo de conteo de apertura (Excel plantilla oficial)",
+        type=["xlsx"],
+    )
     if archivo and st.button("Procesar auditoría de apertura"):
         df = pd.read_excel(archivo)
-        requeridas = ["Fecha", "Item", "Subcategoría", "Ubicación", "Conteo Apertura"]
+        requeridas = ["Fecha", "Item", "Subcategoría", "Conteo Apertura"]
+        if ubic_sel == "General":
+            requeridas.append("Ubicación")
         for req in requeridas:
             if req not in df.columns:
                 st.error(f"Falta columna requerida: {req}")
                 return
+        if ubic_sel != "General":
+            df["Ubicación"] = ubic_sel
         if "Requisicion" not in df.columns:
             df["Requisicion"] = 0
 
@@ -117,14 +131,25 @@ def auditoria_cierre():
     - Genera un reporte detallado.
     """)
     fecha = st.date_input("Fecha de auditoría de cierre", value=datetime.today())
-    archivo = st.file_uploader("Selecciona el archivo de conteo de cierre (Excel plantilla oficial)", type=["xlsx"])
+    ubic_sel = st.selectbox(
+        "Ubicación de la auditoría",
+        ["General"] + UBICACIONES,
+    )
+    archivo = st.file_uploader(
+        "Selecciona el archivo de conteo de cierre (Excel plantilla oficial)",
+        type=["xlsx"],
+    )
     if archivo and st.button("Procesar auditoría de cierre"):
         df = pd.read_excel(archivo)
-        requeridas = ["Fecha", "Item", "Subcategoría", "Ubicación", "Conteo Apertura", "Conteo Cierre"]
+        requeridas = ["Fecha", "Item", "Subcategoría", "Conteo Apertura", "Conteo Cierre"]
+        if ubic_sel == "General":
+            requeridas.append("Ubicación")
         for req in requeridas:
             if req not in df.columns:
                 st.error(f"Falta columna requerida: {req}")
                 return
+        if ubic_sel != "General":
+            df["Ubicación"] = ubic_sel
         if "Requisicion" not in df.columns:
             df["Requisicion"] = 0
 


### PR DESCRIPTION
## Summary
- remove unused template download module and sidebar entry
- allow choosing a location or all when uploading an audit

## Testing
- `python -m py_compile app.py modules/auditorias.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689200333f70832ebfb21731e803eb08