### PR TITLE
Warn when prior closure audit is missing in apertura

### DIFF
--- a/modules/auditorias.py
+++ b/modules/auditorias.py
@@ -94,6 +94,8 @@ def auditoria_apertura():
             prev = pd.read_excel(ult_cierre)
         else:
             prev = pd.DataFrame(columns=["Item", "Ubicación", "Físico Cierre"])
+        if prev.empty:
+            st.warning("No se encontró auditoría de cierre del día anterior.")
         result = []
         for idx, row in df.iterrows():
             cierre_prev = prev[


### PR DESCRIPTION
## Summary
- notify users when the previous day's closing audit is missing while processing opening audit

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68920b1e3010832eabd3370b63c5d81c