### PR TITLE
Handle empty header row in ventas module

### DIFF
--- a/modules/ventas.py
+++ b/modules/ventas.py
@@ -137,7 +137,10 @@ def ventas_module():
 
     if archivo:
         try:
-            df_ventas = pd.read_excel(archivo)
+            # La primera fila del archivo generado por el POS viene vacía,
+            # por lo que se usa header=1 para ignorarla y tomar los nombres
+            # de las columnas de la segunda fila.
+            df_ventas = pd.read_excel(archivo, header=1)
         except Exception as e:
             st.error(f"Error leyendo archivo de ventas: {e}")
             return


### PR DESCRIPTION
## Summary
- Skip empty first row when reading ventas Excel files so column names load correctly

## Testing
- `python -m py_compile modules/ventas.py`
- `python - <<'PY'
import pandas as pd
print('Without header=1:')
print(pd.read_excel('sample_ventas.xlsx').columns.tolist())
print('With header=1:')
print(pd.read_excel('sample_ventas.xlsx', header=1).columns.tolist())
PY`


------
https://chatgpt.com/codex/tasks/task_e_6892141cae14832ebb25eaf04f7043d0