### PR TITLE
feat: add audit excel downloads

### DIFF
--- a/modules/auditorias.py
+++ b/modules/auditorias.py
@@ -49,7 +49,11 @@ def registrar_requisiciones(df_audit, fecha):
     else:
         df_new = pd.DataFrame(registros)
     df_new = df_new.drop_duplicates(subset=["Fecha", "Item", "Desde", "Hacia", "Cantidad"], keep="first")
-    df_new.to_excel(path, index=False)
+    try:
+        with pd.ExcelWriter(path, engine="xlsxwriter") as writer:
+            df_new.to_excel(writer, index=False)
+    except Exception as e:
+        st.error(f"Error guardando transferencias: {e}")
 
 def auditoria_apertura():
     st.title("Auditoría de Apertura")
@@ -115,8 +119,16 @@ def auditoria_apertura():
         df_res = pd.DataFrame(result)
         outfile = f"auditoria_apertura_{fecha.strftime('%Y-%m-%d')}.xlsx"
         pdfout = outfile.replace('.xlsx', '.pdf')
-        df_res.to_excel(os.path.join(AUDITORIA_AP_FOLDER, outfile), index=False)
-        pdf_bytes = generar_pdf_apertura(df_res, os.path.join(REPORTES_PDF_FOLDER, pdfout))
+        out_path = os.path.join(AUDITORIA_AP_FOLDER, outfile)
+        try:
+            with pd.ExcelWriter(out_path, engine="xlsxwriter") as writer:
+                df_res.to_excel(writer, index=False)
+            pdf_bytes = generar_pdf_apertura(
+                df_res, os.path.join(REPORTES_PDF_FOLDER, pdfout)
+            )
+        except Exception as e:
+            st.error(f"Error guardando auditoría: {e}")
+            return
         st.success("Auditoría procesada y registrada.")
         st.dataframe(df_res)
         # USAR EL NUEVO PATRÓN PARA DESCARGA
@@ -243,8 +255,16 @@ def auditoria_cierre():
         df_res = pd.DataFrame(result)
         outfile = f"auditoria_cierre_{fecha.strftime('%Y-%m-%d')}.xlsx"
         pdfout = outfile.replace('.xlsx', '.pdf')
-        df_res.to_excel(os.path.join(AUDITORIA_CI_FOLDER, outfile), index=False)
-        pdf_bytes = generar_pdf_cierre(df_res, os.path.join(REPORTES_PDF_FOLDER, pdfout))
+        out_path = os.path.join(AUDITORIA_CI_FOLDER, outfile)
+        try:
+            with pd.ExcelWriter(out_path, engine="xlsxwriter") as writer:
+                df_res.to_excel(writer, index=False)
+            pdf_bytes = generar_pdf_cierre(
+                df_res, os.path.join(REPORTES_PDF_FOLDER, pdfout)
+            )
+        except Exception as e:
+            st.error(f"Error guardando auditoría: {e}")
+            return
         st.success("Auditoría de cierre procesada y registrada.")
         st.dataframe(df_res)
         st.download_button("Descargar auditoría (Excel)", data=to_excel_bytes(df_res), file_name=outfile)

--- a/modules/entradas.py
+++ b/modules/entradas.py
@@ -20,7 +20,11 @@ def save_entrada(df, fecha):
         df_new = pd.concat([df_old, df], ignore_index=True)
     else:
         df_new = df
-    df_new.to_excel(path, index=False)
+    try:
+        with pd.ExcelWriter(path, engine="xlsxwriter") as writer:
+            df_new.to_excel(writer, index=False)
+    except Exception as e:
+        st.error(f"Error guardando entradas: {e}")
 
 def show_latest_entradas():
     """Muestra las últimas 5 entradas cargadas (de los archivos más recientes)."""

--- a/modules/plantillas.py
+++ b/modules/plantillas.py
@@ -49,7 +49,11 @@ def plantilla_module():
     ruta = os.path.join(PLANTILLAS_FOLDER, nombre_archivo)
 
     # Guardar el archivo plantilla, aunque la app permite descargar directo
-    df_plantilla.to_excel(ruta, index=False)
+    try:
+        with pd.ExcelWriter(ruta, engine="xlsxwriter") as writer:
+            df_plantilla.to_excel(writer, index=False)
+    except Exception as e:
+        st.error(f"Error guardando plantilla: {e}")
 
     st.dataframe(df_plantilla.head(12))
 

--- a/modules/reportes.py
+++ b/modules/reportes.py
@@ -6,7 +6,11 @@ from datetime import datetime
 from modules.catalogo import load_catalog
 from modules.stock import load_last_cierre, calcular_stock_actual
 from utils.pdf_report import generar_pdf_stock
-from utils.path_utils import REPORTES_PDF_DIR
+from utils.path_utils import (
+    REPORTES_PDF_DIR,
+    AUDITORIA_AP_DIR,
+    AUDITORIA_CI_DIR,
+)
 
 
 def _listar_pdfs(patron):
@@ -21,6 +25,21 @@ def _listar_pdfs(patron):
                 data=f,
                 file_name=os.path.basename(archivo),
                 mime="application/pdf",
+            )
+
+
+def _listar_excels(folder):
+    archivos = sorted(glob(os.path.join(folder, "*.xlsx")), reverse=True)
+    if not archivos:
+        st.info("No hay reportes disponibles.")
+        return
+    for archivo in archivos:
+        with open(archivo, "rb") as f:
+            st.download_button(
+                label=os.path.basename(archivo),
+                data=f,
+                file_name=os.path.basename(archivo),
+                mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
             )
 
 
@@ -57,9 +76,17 @@ def reportes_module():
     with tab_diario:
         sub_ap, sub_ci = st.tabs(["Apertura", "Cierre"])
         with sub_ap:
-            _listar_pdfs("auditoria_apertura_*.pdf")
+            ap_pdf, ap_excel = st.tabs(["PDF", "Excel"])
+            with ap_pdf:
+                _listar_pdfs("auditoria_apertura_*.pdf")
+            with ap_excel:
+                _listar_excels(AUDITORIA_AP_DIR)
         with sub_ci:
-            _listar_pdfs("auditoria_cierre_*.pdf")
+            ci_pdf, ci_excel = st.tabs(["PDF", "Excel"])
+            with ci_pdf:
+                _listar_pdfs("auditoria_cierre_*.pdf")
+            with ci_excel:
+                _listar_excels(AUDITORIA_CI_DIR)
         st.caption(
             "Para generar nuevos reportes diarios utilice los módulos de auditoría en el menú principal."
         )

--- a/modules/ventas.py
+++ b/modules/ventas.py
@@ -168,11 +168,16 @@ def ventas_module():
             else:
                 output_file = f"ventas_procesadas_{fecha.strftime('%Y-%m-%d')}.xlsx"
                 out_path = os.path.join(VENTAS_PROCESADAS_FOLDER, output_file)
-                df_proc.to_excel(out_path, index=False)
+                try:
+                    with pd.ExcelWriter(out_path, engine="xlsxwriter") as writer:
+                        df_proc.to_excel(writer, index=False)
+                except Exception as e:
+                    st.error(f"Error guardando ventas procesadas: {e}")
+                    return
                 st.success(f"Ventas procesadas. Archivo guardado como: {output_file}")
                 st.dataframe(df_proc)
                 st.download_button(
-                    label="Descargar consumo teórico", 
+                    label="Descargar consumo teórico",
                     data=to_excel_bytes(df_proc),
                     file_name=output_file,
                     mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",


### PR DESCRIPTION
## Summary
- list audit Excel files alongside PDFs in reports module
- ensure all report writers use `pd.ExcelWriter` context managers

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`
- `python - <<'PY'
import os, pandas as pd
from modules import reportes
from utils.path_utils import AUDITORIA_AP_DIR, AUDITORIA_CI_DIR
# create dummy files and monkeypatch streamlit
for dir_ in [AUDITORIA_AP_DIR, AUDITORIA_CI_DIR]:
    os.makedirs(dir_, exist_ok=True)
    path=os.path.join(dir_, 'test.xlsx')
    with pd.ExcelWriter(path, engine='xlsxwriter') as w:
        pd.DataFrame({'a':[1]}).to_excel(w, index=False)
class Dummy:
    def download_button(self, **kwargs):
        print('download_button called with', kwargs['file_name'])
    def info(self, msg):
        print('info:', msg)
dummy = Dummy()
reportes.st = dummy
print('Listing AP:')
reportes._listar_excels(AUDITORIA_AP_DIR)
print('Listing CI:')
reportes._listar_excels(AUDITORIA_CI_DIR)
PY`

------
https://chatgpt.com/codex/tasks/task_e_689218528678832eaef5bae4d83b7161