### PR TITLE
Simplificar reporte de cierre

### DIFF
--- a/modules/auditorias.py
+++ b/modules/auditorias.py
@@ -242,20 +242,13 @@ def auditoria_cierre():
                 consumo = 0
             teorico_cierre = apertura + entradas_sum + transf_netas - consumo
             diferencia = cierre_fisico - teorico_cierre
-            pct = (diferencia / teorico_cierre) * 100 if teorico_cierre != 0 else 0
             result.append({
                 "Item": item,
                 "Ubicación": ubic,
-                "Apertura": apertura,
-                "Entradas": entradas_sum,
-                "Transferencias Netas": transf_netas,
-                "Salida Teórica": consumo,
-                "Teórico Cierre": teorico_cierre,
-                "Físico Cierre": cierre_fisico,
+                "Teorico": teorico_cierre,
                 "Diferencia": diferencia,
-                "%": round(pct, 2)
             })
-        df_res = pd.DataFrame(result)
+        df_res = pd.DataFrame(result, columns=["Item", "Ubicación", "Teorico", "Diferencia"])
         outfile = f"auditoria_cierre_{fecha.strftime('%Y-%m-%d')}.xlsx"
         pdfout = outfile.replace('.xlsx', '.pdf')
         out_path = os.path.join(AUDITORIA_CI_FOLDER, outfile)


### PR DESCRIPTION
## Summary
- Limitar las columnas del resultado del cierre a Item, Ubicación, Teorico y Diferencia
- Ajustar la creación del DataFrame para reflejar la estructura reducida

## Testing
- `python -m py_compile modules/auditorias.py utils/pdf_report.py`
- `python - <<'PY'
import pandas as pd
from utils.pdf_report import generar_pdf_cierre

df = pd.DataFrame([
    {"Item": "A", "Ubicación": "Barra", "Teorico": 10, "Diferencia": 2},
    {"Item": "B", "Ubicación": "Almacén", "Teorico": 5, "Diferencia": -1},
])

pdf_bytes = generar_pdf_cierre(df)
print('PDF length:', len(pdf_bytes))
print('Sum diferencias:', df['Diferencia'].sum())
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68921f495ec8832e89e96a79abf1343c