### PR TITLE
Simplificar reporte de cierre

### DIFF
--- a/modules/auditorias.py
+++ b/modules/auditorias.py
@@ -102,7 +102,7 @@ def auditoria_apertura():
         if os.path.exists(cierre_prev_path):
             prev = pd.read_excel(cierre_prev_path)
         else:
-            prev = pd.DataFrame(columns=["Item", "Ubicación", "Físico Cierre"])
+            prev = pd.DataFrame(columns=["Item", "Ubicación", "Teorico", "Diferencia"])
             st.warning("No se encontró auditoría de cierre del día anterior.")
         result = []
         for idx, row in df.iterrows():
@@ -110,7 +110,11 @@ def auditoria_apertura():
                 (prev["Item"] == row["Item"]) &
                 (prev["Ubicación"] == row["Ubicación"])
             ]
-            cierre_anterior = float(cierre_prev.iloc[0]["Físico Cierre"]) if not cierre_prev.empty else 0
+            cierre_anterior = (
+                float(cierre_prev.iloc[0]["Teorico"] + cierre_prev.iloc[0]["Diferencia"])
+                if not cierre_prev.empty
+                else 0
+            )
             diferencia = float(row["Conteo Apertura"]) - cierre_anterior
             result.append({
                 "Item": row["Item"],
@@ -242,20 +246,13 @@ def auditoria_cierre():
                 consumo = 0
             teorico_cierre = apertura + entradas_sum + transf_netas - consumo
             diferencia = cierre_fisico - teorico_cierre
-            pct = (diferencia / teorico_cierre) * 100 if teorico_cierre != 0 else 0
             result.append({
                 "Item": item,
                 "Ubicación": ubic,
-                "Apertura": apertura,
-                "Entradas": entradas_sum,
-                "Transferencias Netas": transf_netas,
-                "Salida Teórica": consumo,
-                "Teórico Cierre": teorico_cierre,
-                "Físico Cierre": cierre_fisico,
+                "Teorico": teorico_cierre,
                 "Diferencia": diferencia,
-                "%": round(pct, 2)
             })
-        df_res = pd.DataFrame(result)
+        df_res = pd.DataFrame(result, columns=["Item", "Ubicación", "Teorico", "Diferencia"])
         outfile = f"auditoria_cierre_{fecha.strftime('%Y-%m-%d')}.xlsx"
         pdfout = outfile.replace('.xlsx', '.pdf')
         out_path = os.path.join(AUDITORIA_CI_FOLDER, outfile)

--- a/modules/stock.py
+++ b/modules/stock.py
@@ -114,7 +114,7 @@ def calcular_stock_actual(cat=None, stock_inicial=None):
                     cantidad = (
                         match.iloc[0]["Cantidad"]
                         if "Cantidad" in match.columns
-                        else match.iloc[0].get("Físico Cierre", 0)
+                        else match.iloc[0].get("Teorico", 0) + match.iloc[0].get("Diferencia", 0)
                     )
             if not entradas.empty:
                 entradas_sum = entradas[(entradas["Item"] == item) & (entradas["Ubicación destino"] == ubic)]["Cantidad"].sum()


### PR DESCRIPTION
## Summary
- Limitar las columnas del resultado del cierre a Item, Ubicación, Teorico y Diferencia
- Ajustar la creación del DataFrame para reflejar la estructura reducida
- Calcular el cierre anterior sumando Teorico y Diferencia en apertura y stock

## Testing
- `python -m py_compile modules/auditorias.py modules/stock.py utils/pdf_report.py`
- `python - <<'PY'
import pandas as pd
prev = pd.DataFrame([
    {"Item": "A", "Ubicación": "Barra", "Teorico": 10, "Diferencia": 2}
])
row = {"Item": "A", "Ubicación": "Barra", "Conteo Apertura": 12}
cierre_prev = prev[(prev["Item"] == row["Item"]) & (prev["Ubicación"] == row["Ubicación"])]
cierre_anterior = (
    float(cierre_prev.iloc[0]["Teorico"] + cierre_prev.iloc[0]["Diferencia"])
    if not cierre_prev.empty
    else 0
)
print("cierre_anterior", cierre_anterior)
PY`
- `python - <<'PY'
import pandas as pd
from utils.pdf_report import generar_pdf_cierre

df = pd.DataFrame([
    {"Item": "A", "Ubicación": "Barra", "Teorico": 10, "Diferencia": 2},
    {"Item": "B", "Ubicación": "Almacén", "Teorico": 5, "Diferencia": -1},
])

pdf_bytes = generar_pdf_cierre(df)
print('PDF length:', len(pdf_bytes))
print('Sum diferencias:', df['Diferencia'].sum())
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68921f495ec8832e89e96a79abf1343c