### PR TITLE
Rename apertura column for audit

### DIFF
--- a/modules/auditorias.py
+++ b/modules/auditorias.py
@@ -120,6 +120,7 @@ def auditoria_apertura():
                 "Diferencia": diferencia
             })
         df_res = pd.DataFrame(result)
+        df_res.rename(columns={"Apertura actual": "Conteo Apertura"}, inplace=True)
         outfile = f"auditoria_apertura_{fecha.strftime('%Y-%m-%d')}.xlsx"
         pdfout = outfile.replace('.xlsx', '.pdf')
         out_path = os.path.join(AUDITORIA_AP_FOLDER, outfile)


### PR DESCRIPTION
## Summary
- Rename `Apertura actual` column to `Conteo Apertura` before saving audit
- Ensure saved audit files use `Conteo Apertura` so closing audit can load them

## Testing
- `python -m pytest`
- Verified merge using `Conteo Apertura` header

------
https://chatgpt.com/codex/tasks/task_e_68922e604530832e9d572fe078e57155