### PR TITLE
Add setup and launch scripts

### DIFF
--- a/Abrir la app.command
+++ b/Abrir la app.command
@@ -1,0 +1,5 @@
+#!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/.venv/bin/activate"
+streamlit run "$SCRIPT_DIR/app.py"
+exec "$SHELL"

--- a/Setup (primera vez).command
+++ b/Setup (primera vez).command
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "Python 3 no está instalado. Descárgalo en https://www.python.org/downloads/"
+  exit 1
+fi
+
+python3 -m venv "$SCRIPT_DIR/.venv"
+source "$SCRIPT_DIR/.venv/bin/activate"
+pip install --upgrade pip
+pip install -r "$SCRIPT_DIR/requirements.txt"
+
+cat <<'EOF' > "$SCRIPT_DIR/Abrir la app.command"
+#!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/.venv/bin/activate"
+streamlit run "$SCRIPT_DIR/app.py"
+exec "$SHELL"
+EOF
+
+chmod +x "$SCRIPT_DIR/Abrir la app.command"
+
+echo "Instalación completada. Usa 'Abrir la app.command' para iniciar la app a partir de ahora."

--- a/generate_setup_files.py
+++ b/generate_setup_files.py
@@ -1,0 +1,63 @@
+import os, stat, textwrap
+
+ROOT = os.path.dirname(os.path.abspath(__file__))
+
+requirements = textwrap.dedent("""\
+streamlit
+pandas
+openpyxl
+xlsxwriter
+fpdf2
+""")
+
+setup_script = textwrap.dedent("""\
+#!/bin/bash
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "Python 3 no está instalado. Descárgalo en https://www.python.org/downloads/"
+  exit 1
+fi
+
+python3 -m venv "$SCRIPT_DIR/.venv"
+source "$SCRIPT_DIR/.venv/bin/activate"
+pip install --upgrade pip
+pip install -r "$SCRIPT_DIR/requirements.txt"
+
+cat <<'EOF' > "$SCRIPT_DIR/Abrir la app.command"
+#!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/.venv/bin/activate"
+streamlit run "$SCRIPT_DIR/app.py"
+exec "$SHELL"
+EOF
+
+chmod +x "$SCRIPT_DIR/Abrir la app.command"
+
+echo "Instalación completada. Usa 'Abrir la app.command' para iniciar la app a partir de ahora."
+""")
+
+launch_script = textwrap.dedent("""\
+#!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/.venv/bin/activate"
+streamlit run "$SCRIPT_DIR/app.py"
+exec "$SHELL"
+""")
+
+with open(os.path.join(ROOT, "requirements.txt"), "w") as f:
+    f.write(requirements)
+
+with open(os.path.join(ROOT, "Setup (primera vez).command"), "w") as f:
+    f.write(setup_script)
+
+with open(os.path.join(ROOT, "Abrir la app.command"), "w") as f:
+    f.write(launch_script)
+
+for file in ["Setup (primera vez).command", "Abrir la app.command"]:
+    path = os.path.join(ROOT, file)
+    st = os.stat(path)
+    os.chmod(path, st.st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+print("Archivos de configuración creados.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+streamlit
+pandas
+openpyxl
+xlsxwriter
+fpdf2


### PR DESCRIPTION
## Summary
- add minimal `requirements.txt` for Streamlit inventory app
- provide macOS setup script to create venv and install dependencies
- include launcher script that starts the app inside the virtual environment
- add Python generator to recreate these files with executable permissions
- include Excel and PDF libraries in dependency list

## Testing
- `python generate_setup_files.py`
- `bash -n 'Setup (primera vez).command'`
- `bash -n 'Abrir la app.command'`


------
https://chatgpt.com/codex/tasks/task_e_689233417ea8832ebd8a04f1f80da527